### PR TITLE
Control struct name changed to l2cap

### DIFF
--- a/rtbth_core_bluez.c
+++ b/rtbth_core_bluez.c
@@ -136,7 +136,7 @@ int rtbt_hci_dev_send(struct hci_dev *hdev, struct sk_buff *skb)
 			
 		case HCI_SCODATA_PKT:
 			printk("-->%s():sco len=%d,time=0x%lx\n", __FUNCTION__, skb->len, jiffies);
-			os_ctrl->sco_tx_seq = bt_cb(skb)->control.txseq;
+			os_ctrl->sco_tx_seq = bt_cb(skb)->l2cap.txseq;
 			os_ctrl->sco_time_hci = jiffies;
 			
 			status = hps_ops->hci_sco_data(os_ctrl->dev_ctrl, skb->data, skb->len);


### PR DESCRIPTION
Fixes a build break for 4.2.0-22-generic
